### PR TITLE
Set viewModel as private variable in Window

### DIFF
--- a/DialogBeamProperties/View/BeamProperty.xaml.cs
+++ b/DialogBeamProperties/View/BeamProperty.xaml.cs
@@ -13,20 +13,20 @@ namespace DialogBeamProperties
     /// </summary>
     public partial class DialogBeamProperties : Window, IDisposable
     {
-        public DialogBeamPropertiesViewModel ViewModel;
+        private DialogBeamPropertiesViewModel viewModel;
 
         public DialogBeamProperties(IProperties iproperties, DialogBeamPropertiesViewModel viewModel)
-        {            
+        {
             InitializeComponent();
             InitMessenger();
-            this.ViewModel = viewModel;
-            this.DataContext = ViewModel;
-            ViewModel.SetProtertiesData(iproperties);
+            this.viewModel = viewModel;
+            this.DataContext = viewModel;
+            this.viewModel.SetProtertiesData(iproperties);
         }
 
         public IProperties GetPropertiesData()
         {
-            return ViewModel.GetPropertiesData();
+            return viewModel.GetPropertiesData();
         }
 
         private void InitMessenger()


### PR DESCRIPTION
Why?
   We can always expose a public method(s) if we need to get to the view
model from outside the Window. We are injecting the XdataWriter which is
the critical interface which does all the work for us.